### PR TITLE
Fix for issue #25

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 # su anki PyPI yazilimi markdown desteklemiyor
-with open('README.rst', encoding='utf-8') as f:
+with open('README.rst', encoding='utf-8',errors='ignore') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Error occored on windows 

```
ERROR: Command errored out with exit status 1:
     command: 'C:\python3\python.exe' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\ashis\\AppData\\Local\\Temp\\pip-install-c_3sjy60\\tweet-preprocessor\\setup.py'"'"'; __file__='"'"'C:\\Users\\ashis\\AppData\\Local\\Temp\\pip-install-c_3sjy60\\tweet-preprocessor\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: C:\Users\ashis\AppData\Local\Temp\pip-install-c_3sjy60\tweet-preprocessor\
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\ashis\AppData\Local\Temp\pip-install-c_3sjy60\tweet-preprocessor\setup.py", line 6, in <module>
        long_description = f.read()
      File "C:\python3\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 652: character maps to <undefined>
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

Fix:
Adding a ignore(for errors) while reading the utf file allows the installation to go through