### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ Preprocessing JSON file:
 
     # JSON example
     >>> input_file_name = "sample_json.json"
-    >>> p.clean_file(file_name, options=[p.OPT.URL, p.OPT.MENTION])
+    >>> p.clean_file(input_file_name, options=[p.OPT.URL, p.OPT.MENTION])
     Saved the cleaned tweets to:/tests/artifacts/24052020_013451892752_vkeCMTwBEMmX_clean_file_sample.json
 
 Preprocessing text file:
@@ -139,7 +139,7 @@ Preprocessing text file:
 
     # Text file example
     >>> input_file_name = "sample_txt.txt"
-    >>> p.clean_file(file_name, options=[p.OPT.URL, p.OPT.MENTION])
+    >>> p.clean_file(input_file_name, options=[p.OPT.URL, p.OPT.MENTION])
     Saved the cleaned tweets to:/tests/artifacts/24052020_013451908865_TE9DWX1BjFws_clean_file_sample.txt
 
 Available Options:


### PR DESCRIPTION
I think that there is an error in the README file, corrected in the two examples below
- [Preprocessing json file](https://github.com/aepiotti/preprocessor/blob/master/README.rst#preprocessing-json-file)

- [Preprocessing text file](https://github.com/aepiotti/preprocessor/blob/master/README.rst#preprocessing-text-file)

For example, the original is:
```
>>> input_file_name = "sample_json.json"
>>> p.clean_file(file_name, options=[p.OPT.URL, p.OPT.MENTION])
```

The argument of the `clean_file` method should be the filename stored in **input_file_name** and not in _file_name_
Otherwise we are passing a null variable to the method.

I found the same for the second example (preprocessing text file).