### PR TITLE
Fix #45 (reserved words) and add test

### DIFF
--- a/preprocessor/defines.py
+++ b/preprocessor/defines.py
@@ -58,7 +58,7 @@ class Patterns:
     URL_PATTERN = re.compile(URL_PATTERN_STR, re.IGNORECASE)
     HASHTAG_PATTERN = re.compile(r'#\w*')
     MENTION_PATTERN = re.compile(r'@\w*')
-    RESERVED_WORDS_PATTERN = re.compile(r'^(RT|FAV)')
+    RESERVED_WORDS_PATTERN = re.compile(r'\b(?<![@#])(RT|FAV)\b')
 
     try:
         # UCS-4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,6 +47,12 @@ class PreprocessorTest(unittest.TestCase):
         cleaned_tweet = p.clean(tweet)
         self.assertEqual('expression experience zoxo xoyo', cleaned_tweet)
 
+    def test_clean_reserved_words(self):
+        tweet = "Awesome!!! RT @RT: This is a tweet about art ART. FAV #RT #FAV #hashtag"
+        p.set_options(p.OPT.RESERVED)
+        cleaned_tweet = p.clean(tweet)
+        self.assertEqual('Awesome!!! @RT: This is a tweet about art ART. #RT #FAV #hashtag', cleaned_tweet)
+
     def test_tokenize(self):
         tweet = 'Packathon was a really #nice :) challenging 👌. @packathonorg http://packathon.org'
         p.set_options(p.OPT.URL, p.OPT.HASHTAG, p.OPT.MENTION, p.OPT.EMOJI, p.OPT.SMILEY)


### PR DESCRIPTION
The original [reserved words regex](https://github.com/s/preprocessor/blob/master/preprocessor/defines.py#L61) only captured RT and FAV when they were located at the start of the input string:
```python
RESERVED_WORDS_PATTERN = re.compile(r'^(RT|FAV)')
```

I edited the regex such that:
- It captures RT or FAV anywhere in the input string instead of just at the start
- It does not capture RT or FAV when they are fragments of a different word (e.g. "ART")
- It does not capture RT or FAV when it is immediately preceded by @ (user handle) or \# (hashtag); I'm assuming that these should be handled by the mention and hashtag patterns respectively

I also added a test case that covers these situations.