### PR TITLE
Fix support for non-English texts

### DIFF
--- a/preprocessor/preprocess.py
+++ b/preprocessor/preprocess.py
@@ -46,8 +46,7 @@ class Preprocess:
         return Patterns.RESERVED_WORDS_PATTERN.sub(repl, tweet_string)
 
     def preprocess_emojis(self, tweet_string, repl):
-        processed = Patterns.EMOJIS_PATTERN.sub(repl, tweet_string)
-        return processed.encode('ascii', 'ignore').decode('ascii')
+        return Patterns.EMOJIS_PATTERN.sub(repl, tweet_string)
 
     def preprocess_smileys(self, tweet_string, repl):
         return Patterns.SMILEYS_PATTERN.sub(repl, tweet_string)


### PR DESCRIPTION
The encode('ascii', 'ignore').decode('ascii') strategy does not work for non-English characters. Since emoji regex patterns already exist in defines.py, regex substitute is sufficient to remove the emojis.

Fixes #47 and #48 