### PR TITLE
Fix #2 (punctuations): allows for colons in matching mentions

### DIFF
--- a/preprocessor/defines.py
+++ b/preprocessor/defines.py
@@ -57,7 +57,7 @@ class Patterns:
                       za|zm|zw)\b/?(?!@)))"""
     URL_PATTERN = re.compile(URL_PATTERN_STR, re.IGNORECASE)
     HASHTAG_PATTERN = re.compile(r'#\w*')
-    MENTION_PATTERN = re.compile(r'@\w*:?\s?')
+    MENTION_PATTERN = re.compile(r'@\w*:?')
     RESERVED_WORDS_PATTERN = re.compile(r'\b(?<![@#])(RT|FAV)\b')
 
     try:

--- a/preprocessor/defines.py
+++ b/preprocessor/defines.py
@@ -57,7 +57,7 @@ class Patterns:
                       za|zm|zw)\b/?(?!@)))"""
     URL_PATTERN = re.compile(URL_PATTERN_STR, re.IGNORECASE)
     HASHTAG_PATTERN = re.compile(r'#\w*')
-    MENTION_PATTERN = re.compile(r'@\w*')
+    MENTION_PATTERN = re.compile(r'@\w*:?\s?')
     RESERVED_WORDS_PATTERN = re.compile(r'\b(?<![@#])(RT|FAV)\b')
 
     try:


### PR DESCRIPTION
Mentions in tweets often has colons (@user:).  Current regex `MENTION_PATTERN = re.compile(r'@\w*')` does not search for colons.  I changed to `MENTION_PATTERN = re.compile(r'@\w*:?')` to allow for matching with colons.



