### PR TITLE
Fix: fill `reserved_words` attribute instead the originally undefined attribute `reserved` 

### DIFF
--- a/preprocessor/parse.py
+++ b/preprocessor/parse.py
@@ -44,7 +44,8 @@ class Parse:
 
         for a_parser_method in parser_methods:
             method_to_call = getattr(self, a_parser_method)
-            attr = a_parser_method.split('_')[1]
+            attr = a_parser_method.replace(Defines.PARSE_METHODS_PREFIX,'')
+
 
             items = method_to_call(tweet_string)
             setattr(parse_result_obj, attr, items)


### PR DESCRIPTION
When parsing, `reserved_words` attribute never gets filled, instead a new originally undefined attr `reserved` is created and filled instead.

This is my simple fix to resolve https://github.com/s/preprocessor/issues/55

This may create issues for users who have used the attr `reserved` though. Not sure what the best approach whether to keep `reserved` filled or not.